### PR TITLE
⚡ Bolt: Fix render loops and stabilize context/fetch hooks

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-24 - [Unstable Object Dependencies causing Render Loops]
+**Learning:** In this codebase, `useFetch` was frequently used with inline object literals for `headers` or `body`. Since these are recreated on every render, they trigger `useEffect` infinitely if the fetched data updates a state that causes a re-render of the component using `useFetch`.
+**Action:** Stabilized `useFetch` by stringifying object dependencies and providing a stable `DEFAULT_CONFIG`. Always memoize context providers to prevent cascading re-renders across the app.

--- a/src/components/cart/cart-context/CartCtxProvider.tsx
+++ b/src/components/cart/cart-context/CartCtxProvider.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 
 import { ClearCartAction, ToggleCartAction, UpdateCartAction } from "../CartTypes";
 import { type CartContextValue, type CartItemType, defaultCartState } from "../CartTypes";
@@ -15,24 +15,24 @@ const CartCtxProvider = ({ children }: CartCtxProviderProps) => {
     defaultCartState
   );
 
-  const updateCartHandler = (items: CartItemType[]): void => {
+  const updateCartHandler = useCallback((items: CartItemType[]): void => {
     dispatchCartAction(UpdateCartAction(items));
-  };
+  }, []);
 
-  const clearCartHandler = () => {
+  const clearCartHandler = useCallback(() => {
     dispatchCartAction(ClearCartAction());
-  };
+  }, []);
 
-  const toggleCartHandler = () => {
+  const toggleCartHandler = useCallback(() => {
     dispatchCartAction(ToggleCartAction());
-  };
+  }, []);
 
-  const cartContext: CartContextValue = {
+  const cartContext: CartContextValue = useMemo(() => ({
     state: cartState,
     updateCart: updateCartHandler,
     clearCart: clearCartHandler,
     toggleCart: toggleCartHandler,
-  };
+  }), [cartState, updateCartHandler, clearCartHandler, toggleCartHandler]);
 
   return (
     <CartContext.Provider value={cartContext}>

--- a/src/components/cart/cart-context/CartReducer.test.ts
+++ b/src/components/cart/cart-context/CartReducer.test.ts
@@ -1,4 +1,8 @@
-import type { CartItemType, CartState, ClearCartAction, defaultCartState, ToggleCartAction, updateCart } from "../CartTypes";
+import { describe, expect, test } from "vitest";
+
+import { ClearCartAction, defaultCartState, ToggleCartAction, UpdateCartAction } from "../CartTypes";
+import type { CartItemType, CartState } from "../CartTypes";
+import CartReducer from "./CartReducer";
 
 const createItem = (overrides: Partial<CartItemType> = {}): CartItemType => ({
   id: "item-1",
@@ -13,7 +17,7 @@ describe("CartReducer", () => {
     const state: CartState = { ...defaultCartState };
     const items = [createItem({ amount: 2, price: 10 })];
 
-    const result = CartReducer(state, updateCart(items));
+    const result = CartReducer(state, UpdateCartAction(items));
 
     expect(result.items).toHaveLength(1);
     expect(result.totalAmount).toBe(20);
@@ -26,7 +30,7 @@ describe("CartReducer", () => {
       totalAmount: 8,
     };
 
-    const result = CartReducer(state, updateCart([createItem({ amount: 3, price: 8 })]));
+    const result = CartReducer(state, UpdateCartAction([createItem({ amount: 3, price: 8 })]));
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].amount).toBe(3);

--- a/src/components/layout/menu/hooks/useMenuData.ts
+++ b/src/components/layout/menu/hooks/useMenuData.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 
 import { FIREBASE_ENDPOINT } from "../../../../App";
 import useFetch from "../../../../functions/useFetch";
@@ -8,16 +8,19 @@ export const useMenuData = () => {
   const dbUrl = useRef<string>(FIREBASE_ENDPOINT + "Menu.json");
 
   const { data, error, loading } = useFetch(dbUrl.current);
-  const menuItemsMap = data as MenuData | null;
-  const menuItems: MenuItemType[] = menuItemsMap
-    ? Object.keys(menuItemsMap)
-      .sort((a, b) => a.localeCompare(b))
-      .map((key) => ({
-        ...menuItemsMap[key],
-        name: menuItemsMap[key].name,
-        category: menuItemsMap[key].category
-      }))
-    : [];
+
+  const menuItems = useMemo(() => {
+    const menuItemsMap = data as MenuData | null;
+    return menuItemsMap
+      ? Object.keys(menuItemsMap)
+        .sort((a, b) => a.localeCompare(b))
+        .map((key) => ({
+          ...menuItemsMap[key],
+          name: menuItemsMap[key].name,
+          category: menuItemsMap[key].category
+        }))
+      : [];
+  }, [data]);
 
   return {
     menuItems,

--- a/src/components/layout/menu/hooks/useMenuData.ts
+++ b/src/components/layout/menu/hooks/useMenuData.ts
@@ -2,7 +2,7 @@ import { useMemo, useRef } from "react";
 
 import { FIREBASE_ENDPOINT } from "../../../../App";
 import useFetch from "../../../../functions/useFetch";
-import type { MenuData, MenuItemType } from "../types";
+import type { MenuData } from "../types";
 
 export const useMenuData = () => {
   const dbUrl = useRef<string>(FIREBASE_ENDPOINT + "Menu.json");

--- a/src/functions/useFetch.tsx
+++ b/src/functions/useFetch.tsx
@@ -8,22 +8,30 @@ interface UseFetchRequestConfig extends Omit<RequestInit, 'body'> {
   body?: unknown;
 }
 
+const DEFAULT_CONFIG: UseFetchRequestConfig = { method: "GET" };
+
 const useFetch = <T = unknown>(
   url: string,
-  requestParams: UseFetchRequestConfig = { method: "GET" }
+  requestParams: UseFetchRequestConfig = DEFAULT_CONFIG
 ): FetchResult<T> => {
   const [data, setData] = React.useState<T | null>(null);
   const [loading, setLoading] = React.useState<boolean>(true);
   const [error, setError] = React.useState<string | null>(null);
 
+  // Deconstruct for stable dependency tracking
+  const { method = "GET", headers, body } = requestParams;
+  const headersStr = JSON.stringify(headers);
+  const bodyStr = JSON.stringify(body);
+
   React.useEffect(() => {
     const sendRequest = async (): Promise<void> => {
+      setLoading(true);
       try {
         // Convert requestParams to proper RequestInit
         const fetchConfig: RequestInit = {
-          method: requestParams.method ?? "GET",
-          headers: requestParams.headers,
-          body: requestParams.body !== undefined ? JSON.stringify(requestParams.body) : undefined,
+          method,
+          headers,
+          body: body !== undefined ? JSON.stringify(body) : undefined,
         };
 
         const response = await fetch(url, fetchConfig);
@@ -46,7 +54,7 @@ const useFetch = <T = unknown>(
     };
 
     void sendRequest();
-  }, [url, requestParams]);
+  }, [url, method, headersStr, bodyStr]);
 
   return { data, loading, error };
 };

--- a/src/tests/functions/useFetch_Performance.test.tsx
+++ b/src/tests/functions/useFetch_Performance.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { vi, describe, test, expect, beforeEach } from "vitest";
+import useFetch from "../../functions/useFetch";
+
+describe("useFetch performance", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: "ok" }),
+      })
+    );
+  });
+
+  test("does not re-fetch when parent re-renders with default params", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+
+    const { rerender, result } = renderHook(() => useFetch("/api/test"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Rerender the hook (simulating parent re-render)
+    rerender();
+
+    // It SHOULD NOT call fetch again
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not re-fetch when params are stable", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const params = { method: "GET" as const };
+
+    const { rerender, result } = renderHook(({ p }) => useFetch("/api/test", p), {
+      initialProps: { p: params }
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    rerender({ p: params });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -9,3 +9,18 @@ if (!globalThis.fetch) {
 afterEach(() => {
   vi.restoreAllMocks();
 });
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,23 +6,24 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  // test: {
-  //   environment: "jsdom",
-  //   globals: true,
-  //   setupFiles: "./src/tests/setup.ts",
-  //   coverage: {
-  //     provider: "v8",
-  //     reporter: ["text", "html", "json-summary"],
-  //     include: ["src/**/*.{ts,tsx}"],
-  //     exclude: [
-  //       "src/**/*.d.ts",
-  //       "src/main.tsx",
-  //       "src/vite-env.d.ts",
-  //       "src/types/**",
-  //       "src/assets/**",
-  //       "src/private/**",
-  //       "src/tests/**"
-  //     ]
-  //   }
-  // }
+  // @ts-expect-error - Vitest 2.x and Vite 7 conflict
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./src/tests/setup.ts",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "json-summary"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.d.ts",
+        "src/main.tsx",
+        "src/vite-env.d.ts",
+        "src/types/**",
+        "src/assets/**",
+        "src/private/**",
+        "src/tests/**"
+      ]
+    }
+  }
 })


### PR DESCRIPTION
Identified and resolved several performance bottlenecks related to unstable object references in React hooks and context. These issues were causing infinite render loops and redundant network requests.

Key improvements:
1. **useFetch Stabilization**: Previously, passing inline headers or body objects would trigger `useEffect` on every render. Now, these are stringified for stable dependency tracking.
2. **Context Memoization**: The `CartCtxProvider` now memoizes its value and handlers, preventing unnecessary re-renders of the entire component tree when the provider's parent re-renders.
3. **Menu Data Memoization**: Wrapped Firebase data transformation in `useMemo` to avoid redundant O(n log n) operations.
4. **Test Suite Stability**: Fixed pre-existing test configuration issues and mocked `matchMedia` to allow the test suite to run reliably.

Measurement: Verified via `useFetch_Performance.test.tsx` that effects now only run when data actually changes, and confirmed `Cart.test.tsx` no longer hangs due to OOM from infinite loops.

---
*PR created automatically by Jules for task [7250380885975922357](https://jules.google.com/task/7250380885975922357) started by @syntaxDuck*