### PR TITLE
🛡️ Sentinel: Fix critical Firestore security vulnerability and UI truncation

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Build failure during deployment due to type mismatch.
 **Learning:** Vite 7 `defineConfig` does not recognize the `test` property from Vitest 2.x by default, causing `tsc` errors during the build process.
 **Prevention:** Use `// @ts-expect-error` above the `test` property in `vite.config.ts` to allow production builds to pass when using mixed major versions of Vite and Vitest.
+
+## 2025-05-15 - [Securing Firestore Rules]
+**Vulnerability:** Wide-open Firestore rules (`allow read, write: if true;`) allowed unauthorized access and tampering with all database collections.
+**Learning:** Default Firestore rules are often set to "allow all" during early development, which is a critical security risk if left unchanged. It's essential to implement the Principle of Least Privilege by restricting access to specific collections based on user authentication and document ownership.
+**Prevention:** Always replace "allow all" rules with collection-specific rules. Use `request.auth` to verify user identity and `resource.data` to check document ownership. Prohibit update/delete operations on sensitive collections like `Orders` once submitted.

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,29 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Menu: Public read, restricted write
+    match /Menu/{itemId} {
+      allow read: if true;
+      allow write: if false;
+    }
+
+    // Orders: Private read and create for the owner
+    match /Orders/{orderId} {
+      // Allow user to read only their own orders
+      allow read: if request.auth != null && request.auth.uid == resource.data.user_id;
+
+      // Allow user to create an order for themselves
+      allow create: if request.auth != null
+        && request.resource.data.user_id == request.auth.uid
+        && request.resource.data.status == 'pending';
+
+      // Once submitted, orders should not be modifiable by users
+      allow update, delete: if false;
+    }
+
+    // Default deny for everything else
     match /{document=**} {
-      allow read, write: if true;
+      allow read, write: if false;
     }
   }
 }

--- a/src/components/layout/menu/MenuItem.tsx
+++ b/src/components/layout/menu/MenuItem.tsx
@@ -82,7 +82,7 @@ const MenuItem: React.FC<MenuItemProps> = React.memo(({
               <h3 className="text-xl font-bold text-text mb-2 group-hover:text-primary transition-colors truncate">
                 {name}
               </h3>
-              <p className="text-text/70 leading-relaxed line-clamp-3">
+              <p className="text-text/70 leading-relaxed line-clamp-2">
                 {description}
               </p>
             </div>


### PR DESCRIPTION
This PR addresses a critical security vulnerability where the Firestore database was wide open to unauthorized read/write access.

### 🛡️ Security Fixes:
- **Firestore Rules Locked Down**: The generic `allow read, write: if true;` rule has been replaced with granular rules.
  - **Menu Collection**: Now public read-only, preventing unauthorized modification of menu items.
  - **Orders Collection**: Restricted so that users can only read their own orders and create new ones for themselves. 
  - **Order Integrity**: New orders must have a `pending` status, and existing orders cannot be updated or deleted by users.
  - **Default Deny**: All other collections are denied access by default.

### ✨ UI Improvements:
- **Consistent Truncation**: Updated `MenuItem.tsx` to use `line-clamp-2` instead of `line-clamp-3`, ensuring UI consistency and fixing a failing Vitest case.

### 📖 Documentation:
- **Sentinel Journal**: Added a new entry in `.Jules/sentinel.md` documenting the vulnerability and prevention strategies.

Verification:
- Manually verified `firestore.rules` content.
- Verified `MenuItem.test.tsx` passes.
- Verified `line-clamp-2` is correctly applied in the frontend using Playwright.
- Confirmed production build passes with `pnpm build`.

---
*PR created automatically by Jules for task [11455912427389411525](https://jules.google.com/task/11455912427389411525) started by @syntaxDuck*