### PR TITLE
🎨 Palette: Add immediate success feedback to "Add" button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-02-14 - [Form Accessibility and Cart Interaction]
 **Learning:** Found a common pattern where form validation errors were visually present but not programmatically linked to inputs. Also discovered that interactive cart buttons were incorrectly tied to global UI visibility toggles instead of state mutations.
 **Action:** Standardize form accessibility by adding required indicators (*) to labels and linking validation error messages to inputs using `aria-describedby` with `aria-live="polite"`. Ensure item removal actions in the cart are decoupled from UI visibility logic to prevent accidental cart closure.
+
+## 2026-02-15 - [Immediate Interaction Feedback]
+**Learning:** Users can feel uncertain about whether an item was successfully added to the cart if the only feedback is a small increment in a distant badge. Providing immediate, local feedback on the button itself (state change, icon swap) confirms the action success without requiring the user to shift their focus.
+**Action:** Use a "Success Feedback Loop" on primary action buttons: Change button text (e.g., "Added!"), swap to a success icon (e.g., checkmark), and update ARIA labels to reflect the new state. Revert to the original state after a short delay (e.g., 2 seconds) to keep the UI clean.

--- a/src/tests/components/layout/menu/MenuItemAmount.test.tsx
+++ b/src/tests/components/layout/menu/MenuItemAmount.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
@@ -34,5 +34,37 @@ describe("MenuItemAmount", () => {
     await user.click(screen.getByRole("button", { name: /add to cart/i }));
     expect(onAddToCart).toHaveBeenCalledWith(0);
     expect(onChangeAmount).toHaveBeenCalledTimes(2);
+  });
+
+  test("shows added state when clicked", () => {
+    vi.useFakeTimers();
+    const onChangeAmount = vi.fn();
+    const onAddToCart = vi.fn();
+
+    render(
+      <MenuItemAmount
+        amount={1}
+        onChangeAmount={onChangeAmount}
+        onAddToCart={onAddToCart}
+      />
+    );
+
+    const addButton = screen.getByRole("button", { name: /add to cart/i });
+    fireEvent.click(addButton);
+
+    expect(onAddToCart).toHaveBeenCalledWith(1);
+    expect(screen.getByText(/added!/i)).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
+    expect(addButton).toHaveAttribute("aria-label", "Item added");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole("button", { name: /add to cart/i })).toBeInTheDocument();
+    expect(screen.queryByText(/added!/i)).not.toBeInTheDocument();
+    expect(addButton).not.toBeDisabled();
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
💡 What: Added a Success Feedback Loop to the "Add" button in the menu.
🎯 Why: Confirms item addition locally to the user, reducing uncertainty without requiring eye movement to the cart badge.
♿ Accessibility: Updated `aria-label` during the "Added!" state and ensured screen readers announce the success state.
📸 Feedback: Button pulses slightly and turns green with a checkmark for 2 seconds.

---
*PR created automatically by Jules for task [10352726791259770036](https://jules.google.com/task/10352726791259770036) started by @syntaxDuck*